### PR TITLE
changed compile to implementation in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile files('libs/YouTubeAndroidPlayerApi.jar')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation files('libs/YouTubeAndroidPlayerApi.jar')
 }


### PR DESCRIPTION
I got this error

`Running "flutter packages get" in example...`
`Launching lib\main.dart on Redmi 5A in debug mode...`
`Configuration 'compile' in project ':flutter_youtube' is deprecated. Use 'implementation' instead.`

so I changed word compile to implementation in build.gradle